### PR TITLE
Add prompt unit test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ tzdata==2025.2
 urllib3==2.3.0
 uvicorn==0.34.0
 websockets==15.0.1
+pytest==8.1.1

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from prompt import build_prompt
+
+
+def test_build_prompt_with_interaction_list():
+    interaction = [("Q1", "A1"), ("Q2", "A2")]
+    question = "Q3?"
+    prompt_messages = build_prompt(question, interaction)
+
+    expected_interaction_text = "\n".join([
+        "Usuario: Q1\nAsistente: A1",
+        "Usuario: Q2\nAsistente: A2",
+    ])
+    expected_user_content = (
+        f"Interacci\u00f3n previa:\n{expected_interaction_text}\n\nPregunta:\n{question}"
+    )
+
+    # The result should be a list with system and user messages
+    assert isinstance(prompt_messages, list)
+    assert prompt_messages[1]["role"] == "user"
+    assert prompt_messages[1]["content"] == expected_user_content.strip()


### PR DESCRIPTION
## Summary
- add pytest to requirements
- add unit tests for the `build_prompt` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fff4d1ad083278d198078fc3d06c4