### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,79 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide dummy modules so app can be imported
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=object))
+sys.modules.setdefault(
+    "gradio",
+    types.SimpleNamespace(
+        Blocks=object,
+        Chatbot=object,
+        Row=object,
+        Textbox=object,
+        Button=object,
+        HTML=object,
+        Markdown=object,
+    ),
+)
+
+import app
+
+
+def test_chatbot_interface_updates_history_and_interaccion():
+    app.interaccion.clear()
+    with patch("app.init_client") as mock_init_client, \
+         patch("app.create_completions", return_value="resp") as mock_create:
+        history = []
+        updated, returned = app.chatbot_interface("hello", history)
+        mock_init_client.assert_called_once()
+        mock_create.assert_called_once()
+        called_args = mock_create.call_args[0]
+        assert called_args[0] is mock_init_client.return_value
+        assert called_args[1] == "hello"
+        assert updated == [("hello", "resp")]
+        assert returned is updated
+        assert app.interaccion == [("hello", "resp")]
+
+
+def test_launch_gradio_interface_calls_launch():
+    created = {}
+
+    class DummyBlocks:
+        def __enter__(self):
+            created['demo'] = self
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def launch(self):
+            created['launched'] = True
+
+    class DummyRow:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyComponent:
+        def __init__(self, *args, **kwargs):
+            pass
+        def click(self, *args, **kwargs):
+            pass
+        def submit(self, *args, **kwargs):
+            pass
+
+    with patch("app.gr.Blocks", return_value=DummyBlocks()), \
+         patch("app.gr.Row", return_value=DummyRow()), \
+         patch("app.gr.HTML", new=DummyComponent), \
+         patch("app.gr.Markdown", new=DummyComponent), \
+         patch("app.gr.Chatbot", new=DummyComponent), \
+         patch("app.gr.Textbox", new=DummyComponent), \
+         patch("app.gr.Button", new=DummyComponent), \
+         patch("app.get_html", return_value="css"):
+        app.launch_gradio_interface()
+
+    assert created.get('launched') is True
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, Mock
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide a dummy openai module so config can be imported
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=Mock()))
+
+import config
+
+
+def test_init_client_creates_openai_instance():
+    with patch("config.OpenAI") as mock_openai:
+        client = config.init_client()
+        mock_openai.assert_called_once_with(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="OpenRouter ApiKey",
+        )
+        assert client is mock_openai.return_value
+

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from interface import get_html
+
+
+def test_get_html_contains_expected_css():
+    html = get_html()
+    assert "<style>" in html
+    assert "#chatbot" in html
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide dummy openai before importing config
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=object))
+
+import config
+import app
+
+
+def test_main_calls_init_and_launch():
+    with patch.object(config, "init_client") as mock_init, \
+         patch.object(app, "launch_gradio_interface") as mock_launch:
+        if "main" in sys.modules:
+            del sys.modules["main"]
+        import main
+        mock_init.assert_called_once()
+        mock_launch.assert_called_once()
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from utils import create_completions
+
+
+def test_create_completions_builds_prompt_and_calls_client():
+    mock_client = Mock()
+    mock_message = Mock(content="answer")
+    mock_client.chat.completions.create.return_value = Mock(choices=[Mock(message=mock_message)])
+    with patch("utils.build_prompt", return_value=[{"role": "user", "content": "hi"}]) as mock_build:
+        result = create_completions(mock_client, "question", [("q", "a")])
+
+    mock_build.assert_called_once_with("question", [("q", "a")])
+    mock_client.chat.completions.create.assert_called_once_with(
+        extra_body={},
+        model="meta-llama/llama-4-maverick:free",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert result == "answer"
+


### PR DESCRIPTION
## Summary
- create test coverage for config, utils, app, interface and main modules
- mock external dependencies (openai, gradio) for safer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684000251e348327834834eff4055330